### PR TITLE
Fix UUID error in scan target operations

### DIFF
--- a/pgdn/scanner.py
+++ b/pgdn/scanner.py
@@ -60,8 +60,10 @@ class Scanner:
                 }
             
             # Create a mock node entry for the scanner agent
+            import uuid
             mock_node = {
                 'id': 0,
+                'uuid': str(uuid.uuid4()),  # Add UUID for scan results
                 'address': target,
                 'source': 'manual_scan',
                 'name': f'Direct scan of {target}'

--- a/pgdn/tasks/pipeline_tasks.py
+++ b/pgdn/tasks/pipeline_tasks.py
@@ -193,8 +193,10 @@ def scan_target_task(self, config_dict: Dict[str, Any], target: str, debug: bool
             raise ValueError(f"DNS resolution failed for {target}")
         
         # Create a mock node entry for the scanner agent
+        import uuid
         mock_node = {
             'id': 0,
+            'uuid': str(uuid.uuid4()),  # Add UUID for scan results
             'address': target,
             'source': 'manual_scan',
             'name': f'Direct scan of {target}'

--- a/pgdn/tasks/scan_tasks.py
+++ b/pgdn/tasks/scan_tasks.py
@@ -167,8 +167,10 @@ def parallel_target_scans_task(
                     logger.info(f"Starting scan for {target}")
                     
                     # Create mock node entry
+                    import uuid
                     mock_node = {
                         'id': 0,
+                        'uuid': str(uuid.uuid4()),  # Add UUID for scan results
                         'address': target,
                         'source': 'parallel_scan',
                         'name': f'Parallel scan of {target}'

--- a/tasks/pipeline_tasks.py
+++ b/tasks/pipeline_tasks.py
@@ -193,8 +193,10 @@ def scan_target_task(self, config_dict: Dict[str, Any], target: str, debug: bool
             raise ValueError(f"DNS resolution failed for {target}")
         
         # Create a mock node entry for the scanner agent
+        import uuid
         mock_node = {
             'id': 0,
+            'uuid': str(uuid.uuid4()),  # Add UUID for scan results
             'address': target,
             'source': 'manual_scan',
             'name': f'Direct scan of {target}'

--- a/tasks/scan_tasks.py
+++ b/tasks/scan_tasks.py
@@ -167,8 +167,10 @@ def parallel_target_scans_task(
                     logger.info(f"Starting scan for {target}")
                     
                     # Create mock node entry
+                    import uuid
                     mock_node = {
                         'id': 0,
+                        'uuid': str(uuid.uuid4()),  # Add UUID for scan results
                         'address': target,
                         'source': 'parallel_scan',
                         'name': f'Parallel scan of {target}'


### PR DESCRIPTION
- Add missing 'uuid' key to mock node creation in all scan target methods
- Fixes KeyError: 'uuid' when manual scans fail and _create_failed_result is called
- Updated mock_node creation in:
  - pgdn/scanner.py: scan_target method
  - pgdn/tasks/pipeline_tasks.py: scan_target_task
  - pgdn/tasks/scan_tasks.py: parallel_target_scans_task
  - tasks/pipeline_tasks.py: scan_target_task
  - tasks/scan_tasks.py: parallel_target_scans_task

The NodeScannerAgent expects all nodes to have a UUID for result tracking, but manually created mock nodes were missing this field, causing crashes when scans failed and the error handling tried to access node['uuid'].