### PR TITLE
Fix web_probes import issue in web_probe_runner

### DIFF
--- a/core/web_probe_runner.py
+++ b/core/web_probe_runner.py
@@ -7,15 +7,19 @@ def run_web_probes(address: str, port: int = 80, timeout: int = 5) -> dict:
     Dynamically loads all probe modules in web_probes/ and runs their probe().
     Returns dict {probe_name: result}
     """
-    import web_probes
-    result = {}
-    for finder, name, ispkg in pkgutil.iter_modules(web_probes.__path__):
-        try:
-            module = importlib.import_module(f"web_probes.{name}")
-            if hasattr(module, "probe"):
-                probe_result = module.probe(address, port, timeout=timeout)
-                result[name] = probe_result if probe_result else {"detected": False}
-        except Exception as e:
-            result[name] = {"detected": False}
-    return result
+    try:
+        import web_probes
+        result = {}
+        for finder, name, ispkg in pkgutil.iter_modules(web_probes.__path__):
+            try:
+                module = importlib.import_module(f"web_probes.{name}")
+                if hasattr(module, "probe"):
+                    probe_result = module.probe(address, port, timeout=timeout)
+                    result[name] = probe_result if probe_result else {"detected": False}
+            except Exception as e:
+                result[name] = {"error": f"Failed to load probe {name}: {str(e)}"}
+        return result
+    except Exception as e:
+        return {"error": f"Failed to load web_probes module: {str(e)}"}
+    
 

--- a/pgdn/core/web_probe_runner.py
+++ b/pgdn/core/web_probe_runner.py
@@ -7,15 +7,19 @@ def run_web_probes(address: str, port: int = 80, timeout: int = 5) -> dict:
     Dynamically loads all probe modules in web_probes/ and runs their probe().
     Returns dict {probe_name: result}
     """
-    import web_probes
-    result = {}
-    for finder, name, ispkg in pkgutil.iter_modules(web_probes.__path__):
-        try:
-            module = importlib.import_module(f"web_probes.{name}")
-            if hasattr(module, "probe"):
-                probe_result = module.probe(address, port, timeout=timeout)
-                result[name] = probe_result if probe_result else {"detected": False}
-        except Exception as e:
-            result[name] = {"detected": False}
-    return result
+    try:
+        import pgdn.web_probes as web_probes
+        result = {}
+        for finder, name, ispkg in pkgutil.iter_modules(web_probes.__path__):
+            try:
+                module = importlib.import_module(f"pgdn.web_probes.{name}")
+                if hasattr(module, "probe"):
+                    probe_result = module.probe(address, port, timeout=timeout)
+                    result[name] = probe_result if probe_result else {"detected": False}
+            except Exception as e:
+                result[name] = {"error": f"Failed to load probe {name}: {str(e)}"}
+        return result
+    except Exception as e:
+        return {"error": f"Failed to load web_probes module: {str(e)}"}
+    
 


### PR DESCRIPTION
- Updated import path from 'web_probes' to 'pgdn.web_probes'
- Added better error handling for probe loading failures
- Fixed 'No module named web_probes' error in scan results