### PR TITLE
feat: introduce org_id parameter throughout CLI and library

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -37,11 +37,14 @@ class BaseAgent(ABC):
         return logger
     
     @abstractmethod
-    def run(self, *args, **kwargs) -> Any:
+    def run(self, org_id: Optional[str] = None, *args, **kwargs) -> Any:
         """
         Main execution method for the agent.
         
         This method must be implemented by all concrete agent classes.
+        
+        Args:
+            org_id: Optional organization ID to filter agentic jobs
         
         Returns:
             Results from agent execution
@@ -125,8 +128,14 @@ class ScanAgent(BaseAgent):
         """
         pass
     
-    def run(self, nodes: List[Dict[str, Any]], *args, **kwargs) -> List[Dict[str, Any]]:
-        """Execute node scanning."""
+    def run(self, nodes: List[Dict[str, Any]], org_id: Optional[str] = None, *args, **kwargs) -> List[Dict[str, Any]]:
+        """
+        Execute node scanning.
+        
+        Args:
+            nodes: List of nodes to scan
+            org_id: Optional organization ID to filter agentic jobs
+        """
         return self.scan_nodes(nodes)
 
 
@@ -146,8 +155,14 @@ class ProcessAgent(BaseAgent):
         """
         pass
     
-    def run(self, scan_results: List[Dict[str, Any]], *args, **kwargs) -> List[Dict[str, Any]]:
-        """Execute result processing."""
+    def run(self, scan_results: List[Dict[str, Any]], org_id: Optional[str] = None, *args, **kwargs) -> List[Dict[str, Any]]:
+        """
+        Execute result processing.
+        
+        Args:
+            scan_results: Raw scan results  
+            org_id: Optional organization ID to filter agentic jobs
+        """
         return self.process_results(scan_results)
 
 
@@ -187,8 +202,14 @@ class PublishAgent(BaseAgent):
         else:
             raise ValueError("Either processed_results or scan_id must be provided")
     
-    def run(self, processed_results: Optional[List[Dict[str, Any]]] = None, *args, **kwargs) -> bool:
-        """Execute result publishing."""
+    def run(self, processed_results: Optional[List[Dict[str, Any]]] = None, org_id: Optional[str] = None, *args, **kwargs) -> bool:
+        """
+        Execute result publishing.
+        
+        Args:
+            processed_results: Processed scan results
+            org_id: Optional organization ID to filter agentic jobs
+        """
         if processed_results is not None:
             return self.publish_results(processed_results)
         else:

--- a/agents/process/processor_agent.py
+++ b/agents/process/processor_agent.py
@@ -397,14 +397,16 @@ class ProcessorAgent(ProcessAgent):
             self.logger.error(f"Failed to get processed results: {e}")
             return []
     
-    def run(self, scan_results: Optional[List[Dict[str, Any]]] = None, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, scan_results: Optional[List[Dict[str, Any]]] = None, org_id: Optional[str] = None, *args, **kwargs) -> List[Dict[str, Any]]:
         """
         Execute result processing.
         
         Args:
             scan_results: Optional list of scan results to process
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             List of processed results
         """
+        # TODO: Implement org_id filtering for processing
         return self.process_results(scan_results)

--- a/agents/recon/filecoin_agent.py
+++ b/agents/recon/filecoin_agent.py
@@ -251,10 +251,14 @@ class FilecoinReconAgent(ReconAgent):
             self.logger.error(f"❌ Failed to get Filecoin protocol: {e}")
             return None
 
-    def run(self, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, org_id: Optional[str] = None, *args, **kwargs) -> List[Dict[str, Any]]:
         """
         Execute Filecoin reconnaissance.
         Discovers peers from Docker and public APIs.
+        
+        Args:
+            org_id: Optional organization ID to filter agentic jobs
         """
+        # TODO: Implement org_id filtering for Filecoin reconnaissance
         return self.discover_nodes()
 

--- a/agents/recon/sui_agent.py
+++ b/agents/recon/sui_agent.py
@@ -284,11 +284,15 @@ class SuiReconAgent(ReconAgent):
             self.logger.error(f"❌ Failed to get Sui protocol: {e}")
             return None
 
-    def run(self, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, org_id: Optional[str] = None, *args, **kwargs) -> List[Dict[str, Any]]:
         """
         Execute Sui reconnaissance.
+        
+        Args:
+            org_id: Optional organization ID to filter agentic jobs
         
         Returns:
             List of discovered validator nodes
         """
+        # TODO: Implement org_id filtering for Sui reconnaissance
         return self.discover_nodes()

--- a/agents/scan/node_scanner_agent.py
+++ b/agents/scan/node_scanner_agent.py
@@ -67,7 +67,7 @@ class NodeScannerAgent(ScanAgent):
     detection, SSL testing, and protocol-specific checks.
     """
     
-    def __init__(self, config: Optional[Config] = None, protocol_filter: Optional[str] = None, debug: bool = False):
+    def __init__(self, config: Optional[Config] = None, protocol_filter: Optional[str] = None, debug: bool = False, org_id: Optional[str] = None):
         """
         Initialize node scanner agent.
         
@@ -75,6 +75,7 @@ class NodeScannerAgent(ScanAgent):
             config: Configuration instance
             protocol_filter: Optional protocol to filter nodes by (e.g., 'filecoin', 'sui')
             debug: Enable debug logging for scanners
+            org_id: Optional organization ID to filter agentic jobs
         """
         super().__init__(config, "NodeScannerAgent")
         self.scan_interval_days = self.config.scanning.scan_interval_days
@@ -83,6 +84,7 @@ class NodeScannerAgent(ScanAgent):
         self.max_concurrent_scans = self.config.scanning.max_concurrent_scans
         self.protocol_filter = protocol_filter
         self.debug = debug
+        self.org_id = org_id
         
         # Initialize scanners
         self.generic_scanner = Scanner()
@@ -453,14 +455,18 @@ class NodeScannerAgent(ScanAgent):
             self.logger.error(f"Failed to get recent scans: {e}")
             return []
     
-    def run(self, nodes: Optional[List[Dict[str, Any]]] = None, *args, **kwargs) -> List[Dict[str, Any]]:
+    def run(self, nodes: Optional[List[Dict[str, Any]]] = None, org_id: Optional[str] = None, *args, **kwargs) -> List[Dict[str, Any]]:
         """
         Execute node scanning.
         
         Args:
             nodes: Optional list of specific nodes to scan
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             List of scan results
         """
+        # Update org_id if provided
+        if org_id is not None:
+            self.org_id = org_id
         return self.scan_nodes(nodes)

--- a/pgdn/core/web_probe_runner.py
+++ b/pgdn/core/web_probe_runner.py
@@ -1,0 +1,25 @@
+import os
+import importlib
+import pkgutil
+
+def run_web_probes(address: str, port: int = 80, timeout: int = 5) -> dict:
+    """
+    Dynamically loads all probe modules in web_probes/ and runs their probe().
+    Returns dict {probe_name: result}
+    """
+    try:
+        import pgdn.web_probes as web_probes
+        result = {}
+        for finder, name, ispkg in pkgutil.iter_modules(web_probes.__path__):
+            try:
+                module = importlib.import_module(f"pgdn.web_probes.{name}")
+                if hasattr(module, "probe"):
+                    probe_result = module.probe(address, port, timeout=timeout)
+                    result[name] = probe_result if probe_result else {"detected": False}
+            except Exception as e:
+                result[name] = {"error": f"Failed to load probe {name}: {str(e)}"}
+        return result
+    except Exception as e:
+        return {"error": f"Failed to load web_probes module: {str(e)}"}
+    
+


### PR DESCRIPTION
- Add --org-id CLI argument for filtering agentic jobs
- Update all main CLI functions to accept and pass org_id parameter:
  * run_full_pipeline()
  * run_single_stage()
  * scan_target()
  * run_with_queue()
  * run_parallel_scans()
- Update PipelineOrchestrator and all stage methods to accept org_id
- Update base agent classes (BaseAgent, ScanAgent, ProcessAgent, PublishAgent) to accept org_id in run() methods
- Update concrete agent implementations:
  * NodeScannerAgent constructor and run() method
  * FilecoinReconAgent.run()
  * SuiReconAgent.run()
  * ProcessorAgent.run()
- Update all agent instantiations to pass org_id parameter
- Foundation in place for implementing SQL filtering per function